### PR TITLE
Improve job PCA coloring

### DIFF
--- a/main.py
+++ b/main.py
@@ -319,16 +319,16 @@ def add_broadcast_pca_colored_subplot(broadcasts, agents, fig, axes, position, c
         cbar.set_label(label)
 
     return fig, axes
-def add_broadcast_pca_colored_by_job(broadcasts, agents, chosen_jobs, fig, axes, position):
+def add_broadcast_pca_colored_by_job(broadcasts, agents, chosen_jobs, fig, axes, position, job_names=None):
     """
-    Adds a PCA plot of broadcasts colored by job ID (int), with padded -1 entries shown in gray.
+    Adds a PCA plot of broadcasts colored by job ID (int). Agents with no successful job are colored gray.
 
     Parameters:
         broadcasts (Tensor): shape (N, D)
         agents (List): list of length N
-        chosen_jobs (List or array): list of length N (or shorter/longer)
+        chosen_jobs (List or array): list of length N giving each agent's selected job id or -1
         fig, axes, position: matplotlib layout
-        num_jobs (int): total number of defined jobs (excluding padded -1)
+        job_names (List[str]): names for each job
     """
     from sklearn.decomposition import PCA
     import matplotlib.colors as mcolors
@@ -357,9 +357,16 @@ def add_broadcast_pca_colored_by_job(broadcasts, agents, chosen_jobs, fig, axes,
     sizes = sizes * 200 + 10
 
 
-    # Custom color map: tab10 + gray for -1
+    # Determine number of jobs and set up color map
+    if job_names is None:
+        unique_jobs = [j for j in np.unique(chosen_jobs) if j >= 0]
+        num_jobs = len(unique_jobs)
+        job_names = [str(j) for j in unique_jobs]
+    else:
+        num_jobs = len(job_names)
+
     base_colors = plt.get_cmap("tab10").colors
-    cmap_colors = list(base_colors[:num_jobs]) + [(0.6, 0.6, 0.6)]  # gray at end
+    cmap_colors = [base_colors[i % len(base_colors)] for i in range(num_jobs)] + [(0.6, 0.6, 0.6)]
     cmap = mcolors.ListedColormap(cmap_colors)
 
     # Remap jobs: -1 → num_jobs (the last color, gray)
@@ -375,12 +382,12 @@ def add_broadcast_pca_colored_by_job(broadcasts, agents, chosen_jobs, fig, axes,
     ax.set_ylabel("PC2")
     ax.grid(True)
 
-    # Add colorbar
+    # Add colorbar with job names
     ticks = list(range(num_jobs)) + [num_jobs]
-    tick_labels = [str(i) for i in range(num_jobs)] + ["None"]
+    tick_labels = job_names + ["None"]
     cbar = fig.colorbar(scatter, ax=ax, ticks=ticks)
     cbar.ax.set_yticklabels(tick_labels)
-    cbar.set_label("Job ID")
+    cbar.set_label("Job")
 
     return fig, axes
 
@@ -527,8 +534,26 @@ def add_broadcast_eigenvalue_subplot(broadcasts, step, fig, axes, position):
 
     return fig, axes
 
-def plot_trade_with_supply_demand(before, after, step, agents, broadcasts, job_names=None, chosen_jobs=None):
-    """Visualize trading results along with several diagnostic subplots."""
+def plot_trade_with_supply_demand(before, after, step, agents, broadcasts, job_names=None, chosen_jobs=None, jobs_per_agent=None):
+    """Visualize trading results along with several diagnostic subplots.
+
+    Parameters
+    ----------
+    before, after : array-like
+        Resource matrices before and after trading.
+    step : int
+        Current simulation step.
+    agents : list
+        Agents participating in the simulation.
+    broadcasts : Tensor
+        Broadcast vectors for each agent.
+    job_names : list of str, optional
+        Names of the available jobs.
+    chosen_jobs : list of int, optional
+        Job ids chosen by agents that successfully performed a job.
+    jobs_per_agent : list of int, optional
+        Length-N list giving each agent's job id or -1 if none was performed.
+    """
     import os
     import matplotlib.pyplot as plt
     import numpy as np
@@ -558,7 +583,7 @@ def plot_trade_with_supply_demand(before, after, step, agents, broadcasts, job_n
         fig, axes = add_broadcast_pca_colored_subplot(broadcasts, agents, fig, axes, position=total_plots - 5, color_by="effort")
         fig, axes = add_broadcast_pca_colored_subplot(broadcasts, agents, fig, axes, position=total_plots - 6, color_by="consumption")
         fig, axes = add_broadcast_pca_colored_subplot(broadcasts, agents, fig, axes, position=total_plots - 7, color_by="production")
-        fig, axes = add_broadcast_pca_colored_by_job(broadcasts, agents, chosen_jobs, fig, axes, position=total_plots - 8)
+        fig, axes = add_broadcast_pca_colored_by_job(broadcasts, agents, jobs_per_agent, fig, axes, position=total_plots - 8, job_names=job_names)
         fig, axes = add_social_filter_heatmap_subplot(agents, broadcasts, fig, axes, position=total_plots - 9)
 
 
@@ -857,7 +882,9 @@ def run_simulation():
             social_signals = compute_social_signals(agents, broadcasts)
 
             # --- PRODUCTION ---
-            chosen_jobs = []
+            # Track jobs for all agents; -1 indicates the agent could not perform a job
+            chosen_jobs = []  # successful job selections only
+            jobs_per_agent = [-1] * len(agents)
             efforts = []
             produced = []
             inputs = []
@@ -884,6 +911,7 @@ def run_simulation():
                 if torch.all(agent.resources >= required_input - 1e-6):
                     output = scaled_output * effort
                     chosen_jobs.append(job_id)
+                    jobs_per_agent[i] = job_id
                     efforts.append(effort)
                     produced.append(output)
                     inputs.append(required_input)
@@ -907,6 +935,7 @@ def run_simulation():
                             output = scaled_output * max_effort
                             required_input = job['input'] * max_effort
                             chosen_jobs.append(job_id)
+                            jobs_per_agent[i] = job_id
                             efforts.append(max_effort)
                             produced.append(output)
                             inputs.append(required_input)
@@ -997,7 +1026,9 @@ def run_simulation():
             ])
             if step % plot_freq == 0 :
                 job_names = [job['name'] for job in jobs]
-                plot_trade_with_supply_demand(before_trade, after_trade, step, agents=agents,broadcasts=broadcasts, job_names=job_names, chosen_jobs=chosen_jobs)
+                plot_trade_with_supply_demand(before_trade, after_trade, step, agents=agents,
+                                              broadcasts=broadcasts, job_names=job_names,
+                                              chosen_jobs=chosen_jobs, jobs_per_agent=jobs_per_agent)
 
 
 


### PR DESCRIPTION
## Summary
- color PCA scatter consistently for each job and only show gray for agents without a successful job
- annotate colorbar with job names
- document new `jobs_per_agent` option for job PCA plot

## Testing
- `python -m py_compile main.py`
- `python - <<'EOF'
import main
main.max_steps = 1
main.num_gif = 1
main.run_simulation()
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6882a75721f88329af203472f79a9d7e