### PR TITLE
Fix social weight matrix when broadcasts are numpy arrays

### DIFF
--- a/main.py
+++ b/main.py
@@ -460,8 +460,16 @@ def compute_social_weight_matrix(agents, broadcasts):
     """Return a matrix of social attention weights between agents."""
     num_agents = len(agents)
 
-    if hasattr(broadcasts, "detach"):
-        broadcasts = broadcasts.detach()
+    # Ensure broadcasts are a torch tensor on the correct device
+    if isinstance(broadcasts, np.ndarray):
+        device = agents[0].resources.device
+        broadcasts = torch.tensor(broadcasts, dtype=agents[0].resources.dtype,
+                                 device=device)
+    elif hasattr(broadcasts, "detach"):
+        broadcasts = broadcasts.detach().to(agents[0].resources.device)
+    else:
+        broadcasts = torch.tensor(broadcasts, dtype=agents[0].resources.dtype,
+                                 device=agents[0].resources.device)
 
     weights = torch.zeros(num_agents, num_agents, device=broadcasts.device)
 
@@ -591,8 +599,15 @@ def compute_favorite_agent_graph(agents, broadcasts):
     """Return a directed graph where each agent points to its most attended peer."""
     num_agents = len(agents)
 
-    if hasattr(broadcasts, "detach"):
-        broadcasts = broadcasts.detach()
+    if isinstance(broadcasts, np.ndarray):
+        device = agents[0].resources.device
+        broadcasts = torch.tensor(broadcasts, dtype=agents[0].resources.dtype,
+                                 device=device)
+    elif hasattr(broadcasts, "detach"):
+        broadcasts = broadcasts.detach().to(agents[0].resources.device)
+    else:
+        broadcasts = torch.tensor(broadcasts, dtype=agents[0].resources.dtype,
+                                 device=agents[0].resources.device)
 
     favorites = []
     with torch.no_grad():


### PR DESCRIPTION
## Summary
- ensure `compute_social_weight_matrix` accepts numpy broadcast arrays
- support numpy arrays in `compute_favorite_agent_graph`

## Testing
- `python -m py_compile main.py`
- `python - <<'EOF'
import main
main.max_steps=1
main.num_agents=2
main.num_gif=1
agents = main.run_simulation()
print(len(agents))
EOF`
- `python - <<'EOF'
import torch, numpy as np
import main
agents=[main.Agent().to(main.device) for _ in range(2)]
broad = np.random.rand(2, main.broadcast_dim)
print(type(broad))
weights=main.compute_social_weight_matrix(agents, broad)
print(weights.shape)
EOF`


------
https://chatgpt.com/codex/tasks/task_e_688c05ee51f8832992f775cddf050292